### PR TITLE
Update fenergy_errors.py

### DIFF
--- a/examples/fenergy_errors.py
+++ b/examples/fenergy_errors.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 
-from thermoflow import fenergy_bar, fenergy_bayesian
+from thermoflow import free_energy_bar, free_energy_bayesian
 
 fe = 0
 diss = 100
@@ -19,12 +19,12 @@ def errors(diss, count):
 
     print()
     print(f"Gaussian work, count: {count}, mean dissipation: {diss} kT")
-    print("BAR error:", fenergy_bar(work_f, work_r, uncertainty_method="BAR")[1])
-    print("MBAR error:", fenergy_bar(work_f, work_r, uncertainty_method="MBAR")[1])
-    print("Bayesian error:", fenergy_bayesian(work_f, work_r)[1])
+    print("BAR error:", free_energy_bar(work_f, work_r, uncertainty_method="BAR")[1])
+    print("MBAR error:", free_energy_bar(work_f, work_r, uncertainty_method="MBAR")[1])
+    print("Bayesian error:", free_energy_bayesian(work_f, work_r)[1])
     print(
         "Logistic approx:",
-        fenergy_bar(work_f, work_r, uncertainty_method="Logistic")[1],
+        free_energy_bar(work_f, work_r, uncertainty_method="Logistic")[1],
     )
 
 


### PR DESCRIPTION
seems like some functions were renamed, and the new names weren't updated here. 

Solved by just changing fenergy -> free_energy in a few places.